### PR TITLE
compiler: remove *_{at_most,newer_than}_version()

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -24,11 +24,11 @@
 # if clang_older_than_version(13)
 diag_clang(push)
 diag_clang(ignored "-Wreserved-id-macro")
-# endif // clang_older_than_version(13)
+# endif // __clang_major__ < 13
 # define _POSIX_C_SOURCE 199309L
 # if clang_older_than_version(13)
 diag_clang(pop)
-# endif // clang_older_than_version(13)
+# endif // __clang_major__ < 13
 #endif // !_WIN32 && __STRICT_ANSI__ && !_POSIX_C_SOURCE
 
 #undef HAVE_C23_BOOL

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -12,15 +12,11 @@
                          __clang_patchlevel__)
 # define clang_equal_to_version(...) CMP_V_(==,clang,__VA_ARGS__)
 # define clang_at_least_version(...) CMP_V_(>=,clang,__VA_ARGS__)
-# define clang_newer_than_version(...) CMP_V_(>,clang,__VA_ARGS__)
-# define clang_at_most_version(...) CMP_V_(<=,clang,__VA_ARGS__)
 # define clang_older_than_version(...) CMP_V_(<,clang,__VA_ARGS__)
 # define clang_not_version(...) CMP_V_(!=,clang,__VA_ARGS__)
 #else
 # define clang_equal_to_version(...) 0
 # define clang_at_least_version(...) 0
-# define clang_newer_than_version(...) 0
-# define clang_at_most_version(...) 0
 # define clang_older_than_version(...) 0
 # define clang_not_version(...) 0
 #endif
@@ -31,15 +27,11 @@
                        __GNUC_PATCHLEVEL__)
 # define gcc_equal_to_version(...) CMP_V_(==,gcc,__VA_ARGS__)
 # define gcc_at_least_version(...) CMP_V_(>=,gcc,__VA_ARGS__)
-# define gcc_newer_than_version(...) CMP_V_(>,gcc,__VA_ARGS__)
-# define gcc_at_most_version(...) CMP_V_(<=,gcc,__VA_ARGS__)
 # define gcc_older_than_version(...) CMP_V_(<,gcc,__VA_ARGS__)
 # define gcc_not_version(...) CMP_V_(!=,gcc,__VA_ARGS__)
 #else
 # define gcc_equal_to_version(...) 0
 # define gcc_at_least_version(...) 0
-# define gcc_newer_than_version(...) 0
-# define gcc_at_most_version(...) 0
 # define gcc_older_than_version(...) 0
 # define gcc_not_version(...) 0
 #endif


### PR DESCRIPTION
The compiler version macros append an implicit .0 if the third argument is missing, and an implicit .0.0 if the second is, too. The predictable consequence was that I played myself assuming clang_at_most_version(13) is equivalent to __clang_major__ <= 13, when in fact it only matches up to exactly 13.0.0, but not e.g. 13.0.1 or newer.

To uphold the tradition of being too clever for my own good, instead of removing the implicit version completion feature, I'll delete the worst foot-gun macros, only keeping ones whose behavior resembles the begin() and end() of C++ iterators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated how compiler version checks are handled for improved clarity and consistency.
	- Removed outdated version comparison macros to streamline internal maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->